### PR TITLE
.about.yml is invalid - set owner_type: working-group

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -3,3 +3,4 @@ name: datascience
 full_name: Data Science Working Group
 private:
   slack: wg-datascience
+owner_type: working-group


### PR DESCRIPTION
Questions? You can read more about the spec here: https://github.com/18F/about_yml
Is this pull incorrect? File an issue at https://github.com/sharms/meta-machine
